### PR TITLE
Format DBNull values as NULL instead of empty string

### DIFF
--- a/src/FunctionalTest/Smo/ScriptingTests/PartitionFunction_SmoTestSuite.cs
+++ b/src/FunctionalTest/Smo/ScriptingTests/PartitionFunction_SmoTestSuite.cs
@@ -85,7 +85,7 @@ namespace Microsoft.SqlServer.Test.SMO.ScriptingTests
                 scripter.Options.ContinueScriptingOnError = true;
                 var scripts = scripter.EnumScript(partitionFunction).ToArray();
                 Assert.That(scripts.Length, Is.EqualTo(1), "Unexpected script count. Expected a single script.");
-                Assert.IsTrue(scripts[0].Contains("VALUES (NULL, 10, 100)"));
+                Assert.That(scripts[0], Contains.Substring("VALUES (NULL, 10, 100)"), "Invalid correct script for null ranged function");
             });
         }
 

--- a/src/Microsoft/SqlServer/Management/Smo/SqlSmoObject.cs
+++ b/src/Microsoft/SqlServer/Management/Smo/SqlSmoObject.cs
@@ -7024,7 +7024,7 @@ namespace Microsoft.SqlServer.Management.Smo
 
         internal static string FormatSqlVariant(object sqlVariant)
         {
-            if (sqlVariant == null)
+            if (sqlVariant == null || DBNull.Value.Equals(sqlVariant))
             {
                 return "NULL";
             }


### PR DESCRIPTION
The formatter did not handle the value being of type `DBNull`, causing it to call `.ToString()` on the object, returning an empty string instead of `NULL`.