### PR TITLE
Added necessary script fields to UserDefinedFunctions

### DIFF
--- a/src/Microsoft/SqlServer/Management/Smo/UserDefinedFunctionBase.cs
+++ b/src/Microsoft/SqlServer/Management/Smo/UserDefinedFunctionBase.cs
@@ -826,7 +826,9 @@ namespace Microsoft.SqlServer.Management.Smo
                             "FunctionType",
                             "IsSchemaBound",
                             "IsNativelyCompiled",
-                            "IsEncrypted"};
+                            "IsEncrypted",
+                            "ReturnsNullOnNullInput",
+                            "InlineType"};
                         List<string> list = GetSupportedScriptFields(typeof(UserDefinedFunction.PropertyMetadataProvider),fields, version, databaseEngineType, databaseEngineEdition);
                         list.Add("Text");
                         return list.ToArray();
@@ -847,6 +849,7 @@ namespace Microsoft.SqlServer.Management.Smo
                         "IsSchemaBound",
                         "IsNativelyCompiled",
                         "IsEncrypted",
+                        "InlineType",
                         "AnsiNullsStatus",
                         "TableVariableName",
                         "XmlSchemaNamespace",

--- a/src/Microsoft/SqlServer/Management/Smo/UserDefinedFunctionBase.cs
+++ b/src/Microsoft/SqlServer/Management/Smo/UserDefinedFunctionBase.cs
@@ -818,17 +818,17 @@ namespace Microsoft.SqlServer.Management.Smo
             if (defaultTextMode)
                 {
                        string[] fields = {
-                            "ImplementationType",
-                            "ID",
-                            "IsSystemObject",
-                            "QuotedIdentifierStatus",
-                            "AnsiNullsStatus",
-                            "FunctionType",
-                            "IsSchemaBound",
-                            "IsNativelyCompiled",
-                            "IsEncrypted",
-                            "ReturnsNullOnNullInput",
-                            "InlineType"};
+                            nameof(AnsiNullsStatus),
+                            nameof(FunctionType),
+                            nameof(ID),
+                            nameof(ImplementationType),
+                            nameof(InlineType),
+                            nameof(IsEncrypted),
+                            nameof(IsNativelyCompiled),
+                            nameof(IsSchemaBound),
+                            nameof(IsSystemObject),
+                            nameof(QuotedIdentifierStatus),
+                            nameof(ReturnsNullOnNullInput)};
                         List<string> list = GetSupportedScriptFields(typeof(UserDefinedFunction.PropertyMetadataProvider),fields, version, databaseEngineType, databaseEngineEdition);
                         list.Add("Text");
                         return list.ToArray();
@@ -836,33 +836,33 @@ namespace Microsoft.SqlServer.Management.Smo
                 else
                 {
                     string[] fields = {
-                        "ImplementationType",
-                        "ID",
+                        nameof(AnsiNullsStatus),
+                        nameof(AssemblyName),
+                        nameof(ClassName),
                         "DataTypeSchema",
-                        "SystemType",
+                        nameof(ExecutionContext),
+                        nameof(ExecutionContextPrincipal),
+                        nameof(FunctionType),
+                        nameof(ID),
+                        nameof(ImplementationType),
+                        nameof(InlineType),
+                        nameof(IsEncrypted),
+                        nameof(IsNativelyCompiled),
+                        nameof(IsSchemaBound),
+                        nameof(IsSchemaOwned),
+                        nameof(IsSystemObject),
                         "Length",
+                        nameof(MethodName),
                         "NumericPrecision",
                         "NumericScale",
-                        "IsSystemObject",
-                        "QuotedIdentifierStatus",
-                        "FunctionType",
-                        "IsSchemaBound",
-                        "IsNativelyCompiled",
-                        "IsEncrypted",
-                        "InlineType",
-                        "AnsiNullsStatus",
-                        "TableVariableName",
-                        "XmlSchemaNamespace",
-                        "XmlSchemaNamespaceSchema",
+                        nameof(Owner),
+                        nameof(QuotedIdentifierStatus),
+                        nameof(ReturnsNullOnNullInput),
+                        "SystemType",
+                        nameof(TableVariableName),
                         "XmlDocumentConstraint",
-                        "ExecutionContext",
-                        "ExecutionContextPrincipal",
-                        "ReturnsNullOnNullInput",
-                        "AssemblyName",
-                        "MethodName",
-                        "ClassName",
-                        "Owner",
-                        "IsSchemaOwned"};
+                        "XmlSchemaNamespace",
+                        "XmlSchemaNamespaceSchema"};
                         List<string> list = GetSupportedScriptFields(typeof(UserDefinedFunction.PropertyMetadataProvider),fields, version, databaseEngineType, databaseEngineEdition);
                         list.Add("Text");
                         list.Add("DataType");


### PR DESCRIPTION
`InlineType` and `ReturnsNullOnNullInput` are both used for scripting UDFs, however, they're not in the array returned by `GetScriptFields`. This leads to the fields not being prefetched, and a lot of round-trips for scripting.

## Usages in scripting: 
`InlineType`: https://github.com/microsoft/sqlmanagementobjects/blob/main/src/Microsoft/SqlServer/Management/Smo/UserDefinedFunctionBase.cs#L299

`ReturnsNullOnNullInput`: https://github.com/microsoft/sqlmanagementobjects/blob/main/src/Microsoft/SqlServer/Management/Smo/UserDefinedFunctionBase.cs#L314