### PR TITLE
Make sure to pass enum type to EnumConverter

### DIFF
--- a/src/Microsoft/SqlServer/Management/ConnectionInfo/LocalizableTypeConverter.cs
+++ b/src/Microsoft/SqlServer/Management/ConnectionInfo/LocalizableTypeConverter.cs
@@ -633,7 +633,7 @@ namespace Microsoft.SqlServer.Management.Common
         /// <param name="type"></param>
         /// <param name="manager"></param>
         internal CommonLocalizableEnumConverter(System.Type type, ResourceManager manager)
-            : base(type.GetType())
+            : base(type)
         {
             // we get a resource manager from the LocalizableTypeCoverter so we just keep using that one
             LoadLocalizedNames(type, manager);
@@ -646,7 +646,7 @@ namespace Microsoft.SqlServer.Management.Common
         /// </summary>
         /// <param name="type"></param>
         public CommonLocalizableEnumConverter(System.Type type)
-            : base(type.GetType())
+            : base(type)
         {
             // we don't have a resource manager yet so we need to go get one from the attribute.
             ResourceManager manager = null;

--- a/src/Microsoft/SqlServer/Management/Sdk/Sfc/LocalizableTypeConverter.cs
+++ b/src/Microsoft/SqlServer/Management/Sdk/Sfc/LocalizableTypeConverter.cs
@@ -1621,7 +1621,7 @@ namespace Microsoft.SqlServer.Management.Sdk.Sfc
         /// <param name="type"></param>
         /// <param name="manager"></param>
         internal LocalizableEnumConverter(System.Type type, ResourceManager manager)
-            : base(type.GetType())
+            : base(type)
         {
             // we get a resource manager from the LocalizableTypeCoverter so we just keep using that one
             LoadLocalizedNames(type, manager);
@@ -1634,7 +1634,7 @@ namespace Microsoft.SqlServer.Management.Sdk.Sfc
         /// </summary>
         /// <param name="type"></param>
         public LocalizableEnumConverter(System.Type type)
-            : base(type.GetType())
+            : base(type)
         {
             // we don't have a resource manager yet so we need to go get one from the attribute.
             ResourceManager manager = null;

--- a/src/UnitTest/ConnectionInfo/LocalizableTypeConverterTests.cs
+++ b/src/UnitTest/ConnectionInfo/LocalizableTypeConverterTests.cs
@@ -68,6 +68,9 @@ namespace Microsoft.SqlServer.ConnectionInfoUnitTests
                 TypeConverter typeConverter = TypeDescriptor.GetConverter(type);
                 Assert.That(typeConverter, Is.Not.Null, "Type {0} did not have a TypeConverter defined", type.Name);
 
+                // ensure the converter accepts the enum value as valid
+                Assert.That(typeConverter.IsValid(enumValue), Is.True);
+
                 FieldInfo fi = type.GetField(Enum.GetName(type, enumValue));
 
                 string typeConverterString =


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/108160

These were passing the type of the type, IOW System.Type which resulted in some members of the TypeConverter returning bad results, and caused an exception on construction in .NET 9.0.