### PR TITLE
SmoMetadataProvider: guard null current-database in Server..ctor (avoid NullReferenceException)

### DIFF
--- a/src/Microsoft/SqlServer/Management/SmoMetadataProvider/Server.cs
+++ b/src/Microsoft/SqlServer/Management/SmoMetadataProvider/Server.cs
@@ -100,8 +100,22 @@ namespace Microsoft.SqlServer.Management.SmoMetadataProvider
                 }
                 else
                 {
-                    var smoDb =
-                        this.m_smoMetadataObject.Databases[this.m_smoMetadataObject.ConnectionContext.DatabaseName];
+                    string currentDatabaseName = this.m_smoMetadataObject.ConnectionContext.DatabaseName;
+                    var smoDb = this.m_smoMetadataObject.Databases[currentDatabaseName];
+
+                    // On an Azure/Fabric endpoint we have no access to 'master' and only add the current
+                    // database. If it cannot be resolved by name (inaccessible, or the endpoint catalog does
+                    // not expose that exact name) the SMO Databases indexer returns null. Guard against it:
+                    // otherwise a null-backed Database is added and its Name is later dereferenced, throwing
+                    // a bare NullReferenceException from inside the metadata collection that cannot be diagnosed.
+                    if (smoDb == null)
+                    {
+                        throw new InvalidOperationException(string.Format(
+                            System.Globalization.CultureInfo.CurrentCulture,
+                            "The database '{0}' could not be found or is not accessible on server '{1}'.",
+                            currentDatabaseName, this.m_smoMetadataObject.Name));
+                    }
+
                     databases.Add(new Database(smoDb, this));
                 }
                 this.SetDatabases(databases);


### PR DESCRIPTION
## What

Guards the current-database lookup in `SmoMetadataProvider.Server..ctor` so an unresolvable current database no longer produces a bare `System.NullReferenceException`.

Fixes #227.

## Why

For an Azure/Fabric SQL endpoint (`ServerType == SqlAzureDatabase`), `smoMasterDb` is forced `null`, so the constructor takes the "no access to master, only add the current database" else-branch and adds `Databases[ConnectionContext.DatabaseName]` **with no null-check**. When that lookup returns `null` (the current database is inaccessible, or not exposed by that exact name in the catalog), a null-backed `Database` is added and its `Name` getter is later dereferenced inside `DictionaryCollectionBase.Add`, throwing an un-diagnosable "Object reference not set to an instance of an object."

This surfaces in tools that reuse SmoMetadataProvider for T-SQL IntelliSense / query validation (Azure Data Studio, the VS Code SQL extension, and Fabric's Data Agent "NL2SQL" example-query validation) against Azure SQL / Fabric SQL analytics endpoints. Full stack trace and a deterministic repro are in #227.

## Change

`src/Microsoft/SqlServer/Management/SmoMetadataProvider/Server.cs`: null-check `smoDb` before wrapping/adding it, and throw a clear `InvalidOperationException` naming the database and server instead of letting a bare `NullReferenceException` escape from deep inside the metadata collection.

## Alternative considered

Instead of throwing, the unresolved database could be **skipped** (with a trace), letting the provider build with the `master` placeholder for graceful IntelliSense degradation — consistent with the connected-mode "suppress and continue" pattern in `TryRefreshSmoCollection`. I have that variant ready too and am happy to switch if you prefer it (raised the throw-vs-skip choice in #227).

## Notes / open questions

- **Exception type & localization:** used `InvalidOperationException` with an inline message for minimal surface area. Happy to switch to a typed exception and/or move the string to a localized resource file if that's the convention here.
- **Test:** reliably driving `Databases[name] -> null` while the login still succeeds is environment-dependent, so I did not add a functional test that could be flaky in CI. A proposed test (assert no `NullReferenceException` / a clear typed error when the current database is unresolvable) is described in #227 — glad to wire it to the existing `MetadataProviderTests` harness with your guidance, or add a targeted test that invokes the internal `Server` construction path.